### PR TITLE
fix: fixes after design review

### DIFF
--- a/packages/ui/src/components/file-additions-trigger.tsx
+++ b/packages/ui/src/components/file-additions-trigger.tsx
@@ -30,13 +30,13 @@ export const FileAdditionsTrigger: FC<FileAdditionsTriggerProps> = ({
       </DropdownMenu.Trigger>
       <DropdownMenu.Content className="min-w-[157px]" align="end">
         <DropdownMenu.Item>
-          <Link className="relative grid grid-cols-[auto_1fr] items-center gap-2.5" to={pathNewFile}>
+          <Link className="relative grid grid-cols-[auto_1fr] items-center gap-1.5" to={pathNewFile}>
             <Icon name="plus" size={12} />
             <span className="truncate">{t('views:repos.create-new-file-no-plus', 'Create new file')}</span>
           </Link>
         </DropdownMenu.Item>
         <DropdownMenu.Item>
-          <Link className="relative grid grid-cols-[auto_1fr] items-center gap-2.5" to={pathUploadFiles}>
+          <Link className="relative grid grid-cols-[auto_1fr] items-center gap-1.5" to={pathUploadFiles}>
             <Icon name="upload" size={12} />
             <span className="truncate">{t('views:repos.upload-files', 'Upload files')}</span>
           </Link>

--- a/packages/ui/src/views/pipelines/create-pipeline-dialog/create-pipeline-dialog.tsx
+++ b/packages/ui/src/views/pipelines/create-pipeline-dialog/create-pipeline-dialog.tsx
@@ -97,7 +97,7 @@ export function CreatePipelineDialog(props: CreatePipelineDialogProps) {
           <Fieldset>
             <Input
               id="name"
-              label="Pipeline name *"
+              label="Pipeline name"
               {...register('name')}
               size="md"
               error={errors.name?.message?.toString()}
@@ -107,7 +107,7 @@ export function CreatePipelineDialog(props: CreatePipelineDialogProps) {
           <Fieldset>
             <Input
               id="yamlPath"
-              label="Yaml path *"
+              label="Yaml path"
               {...register('yamlPath')}
               size="md"
               error={errors.name?.message?.toString()}
@@ -122,7 +122,7 @@ export function CreatePipelineDialog(props: CreatePipelineDialogProps) {
                 value={branch}
                 onValueChange={value => handleSelectChange('branch', value)}
                 placeholder="Select"
-                label="Branch *"
+                label="Branch"
               >
                 <SelectContent>
                   {branchNames?.map(branchName => (

--- a/packages/ui/src/views/pipelines/pipeline-list/pipeline-list-page.tsx
+++ b/packages/ui/src/views/pipelines/pipeline-list/pipeline-list-page.tsx
@@ -49,25 +49,29 @@ const PipelineListPage: FC<IPipelineListPageProps> = ({
   return (
     <SandboxLayout.Main className="max-w-[1040px]">
       <SandboxLayout.Content>
-        <h1 className="text-24 font-medium leading-snug tracking-tight text-foreground-1">Pipelines</h1>
-        <Spacer size={6} />
-        <ListActions.Root>
-          <ListActions.Left>
-            <SearchBox.Root
-              width="full"
-              className="max-w-96"
-              value={searchInput}
-              handleChange={handleInputChange}
-              placeholder={'Search'}
-            />
-          </ListActions.Left>
-          <ListActions.Right>
-            <Button variant="default" onClick={handleCreatePipeline}>
-              Create pipeline
-            </Button>
-          </ListActions.Right>
-        </ListActions.Root>
-        <Spacer size={5} />
+        {pipelines && pipelines.length > 0 && (
+          <>
+            <h1 className="text-24 font-medium leading-snug tracking-tight text-foreground-1">Pipelines</h1>
+            <Spacer size={6} />
+            <ListActions.Root>
+              <ListActions.Left>
+                <SearchBox.Root
+                  width="full"
+                  className="max-w-96"
+                  value={searchInput}
+                  handleChange={handleInputChange}
+                  placeholder={'Search'}
+                />
+              </ListActions.Left>
+              <ListActions.Right>
+                <Button variant="default" onClick={handleCreatePipeline}>
+                  Create pipeline
+                </Button>
+              </ListActions.Right>
+            </ListActions.Root>
+            <Spacer size={5} />
+          </>
+        )}
         <PipelineList
           pipelines={pipelines}
           LinkComponent={LinkComponent}

--- a/packages/ui/src/views/repo/components/path-action-bar.tsx
+++ b/packages/ui/src/views/repo/components/path-action-bar.tsx
@@ -45,14 +45,14 @@ export const PathActionBar: FC<PathActionBarProps> = ({
       />
       {codeMode === CodeModes.VIEW && pathNewFile && pathUploadFiles && (
         <Button variant="outline">
-          <Link className="relative grid grid-cols-[auto_1fr] items-center gap-2.5" to={pathNewFile}>
+          <Link className="relative grid grid-cols-[auto_1fr] items-center gap-1.5" to={pathNewFile}>
             <Icon name="plus" size={12} />
             <span className="truncate">{t('views:repos.create-new-file-no-plus', 'Create new file')}</span>
           </Link>
         </Button>
       )}
       {codeMode !== CodeModes.VIEW && (
-        <div className="flex gap-3">
+        <div className="flex gap-2.5">
           {!!handleCancelFileEdit && (
             <Button variant="outline" onClick={handleCancelFileEdit}>
               Cancel changes

--- a/packages/ui/src/views/repo/pull-request/components/pull-request-header.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/pull-request-header.tsx
@@ -139,7 +139,7 @@ export const PullRequestHeader: React.FC<PullRequestTitleProps> = ({
           <span>into</span>
           <Badge variant="tertiary" size="md" borderRadius="base">
             <Link
-              className="flex items-center gap-x-1"
+              className="flex items-center gap-x-1.5"
               to={`${spaceId ? `/${spaceId}` : ''}/repos/${repoId}/code/${target_branch}`}
             >
               <Icon name="branch" size={12} className="text-icons-9" />

--- a/packages/ui/src/views/repo/repo-files/index.tsx
+++ b/packages/ui/src/views/repo/repo-files/index.tsx
@@ -142,7 +142,7 @@ export const RepoFiles: FC<RepoFilesProps> = ({
   ])
 
   return (
-    <SandboxLayout.Main className="max-w-[1400px]">
+    <SandboxLayout.Main fullWidth>
       <SandboxLayout.Content className="flex h-full flex-col pt-4">
         {isView && !isRepoEmpty && (
           <PathActionBar

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -175,7 +175,7 @@ export function RepoSummaryView({
             */}
             <ListActions.Root>
               <ListActions.Left>
-                <ButtonGroup>
+                <ButtonGroup className="gap-2.5">
                   <BranchSelector
                     onSelectBranch={selectBranchOrTag}
                     useRepoBranchesStore={useRepoBranchesStore}
@@ -191,10 +191,10 @@ export function RepoSummaryView({
                 </ButtonGroup>
               </ListActions.Left>
               <ListActions.Right>
-                <ButtonGroup>
+                <ButtonGroup className="gap-2.5">
                   <Button variant="outline">
                     <Link
-                      className="relative grid grid-cols-[auto_1fr] items-center gap-2.5"
+                      className="relative grid grid-cols-[auto_1fr] items-center gap-1.5"
                       to={`${spaceId ? `/${spaceId}` : ''}/repos/${repoId}/code/new/${gitRef || selectedBranchTag?.name || ''}/~/`}
                     >
                       <Icon name="plus" size={12} />


### PR DESCRIPTION
This PR brings small design updates for repo summary and pipeline pages:

1. Pipelines page

**Before:**

<img width="1260" alt="b1" src="https://github.com/user-attachments/assets/b32bddcd-bd4c-4aef-a65e-d5df31e72751" />

**After**

<img width="1270" alt="a1" src="https://github.com/user-attachments/assets/11ee5da9-eb38-4e0b-aa21-32c3865e6cab" />

**Before**

<img width="609" alt="b2" src="https://github.com/user-attachments/assets/b9ce9c52-6a61-4024-bca2-eb63f762ebb9" />

**After**

<img width="630" alt="a2" src="https://github.com/user-attachments/assets/32ac6992-10c0-4ac0-a5b7-50ee6848e60d" />

2. Repo summary

![CleanShot 2025-01-28 at 14 01 26@2x](https://github.com/user-attachments/assets/7d025536-2c38-4a50-bdfb-2b768f2de413)

