### PR TITLE
fix UI when error message takes more than 1 line, improve validation

### DIFF
--- a/packages/ui/locales/en/views.json
+++ b/packages/ui/locales/en/views.json
@@ -434,6 +434,17 @@
     "noExpiration": "No Expiration",
     "deleteToken": "Delete token",
     "noTokenDescription": "There are no personal access tokens associated with this account.",
+    "validation": {
+      "nameMin": "Please provide your name",
+      "nameMax": "Name must be no longer than 256 characters",
+      "usernameMin": "Please provide a username",
+      "emailInvalid": "Please provide a valid email address",
+      "emailMax": "Email must be no longer than 250 characters",
+      "passwordMin": "New password must be at least 6 characters",
+      "passwordMax": "New password must be no longer than 128 characters",
+      "confirmPasswordMin": "Please confirm your new password",
+      "passwordsDoNotMatch": "Passwords do not match"
+    },
     "accountSettings": "Account settings",
     "personalInfo": "Personal information",
     "enterUsernamePlaceholder": "Enter your username",

--- a/packages/ui/locales/fr/views.json
+++ b/packages/ui/locales/fr/views.json
@@ -407,6 +407,17 @@
     "noExpiration": "Pas d'expiration",
     "deleteToken": "Delete token",
     "noTokenDescription": "Il n'y a aucun jeton d'accès personnel associé à ce compte.",
+    "validation": {
+      "nameMin": "Veuillez indiquer votre nom",
+      "nameMax": "Le nom ne doit pas dépasser 256 caractères",
+      "usernameMin": "Veuillez fournir un nom d'utilisateur",
+      "emailInvalid": "Veuillez fournir une adresse e-mail valide",
+      "emailMax": "L'e-mail ne doit pas dépasser 250 caractères",
+      "passwordMin": "Le nouveau mot de passe doit contenir au moins 6 caractères",
+      "passwordMax": "Le nouveau mot de passe ne doit pas dépasser 128 caractères",
+      "confirmPasswordMin": "Veuillez confirmer votre nouveau mot de passe",
+      "passwordsDoNotMatch": "Les mots de passe ne correspondent pas"
+    },
     "accountSettings": "Paramètres du compte",
     "personalInfo": "Informations personnelles",
     "enterUsernamePlaceholder": "Entrez votre nom d'utilisateur",

--- a/packages/ui/src/components/form-primitives/caption.tsx
+++ b/packages/ui/src/components/form-primitives/caption.tsx
@@ -1,6 +1,5 @@
 import { PropsWithChildren } from 'react'
 
-import { Text } from '@/components'
 import { cn } from '@utils/cn'
 
 interface CaptionProps extends PropsWithChildren<React.HTMLAttributes<HTMLElement>> {
@@ -14,9 +13,5 @@ interface CaptionProps extends PropsWithChildren<React.HTMLAttributes<HTMLElemen
  * <Caption>This is a caption</Caption>
  */
 export function Caption({ children, className }: CaptionProps) {
-  return (
-    <Text className={cn('text-foreground-4 mt-1 leading-snug', className)} size={2}>
-      {children}
-    </Text>
-  )
+  return <span className={cn('text-foreground-4 mt-1 leading-snug text-sm', className)}>{children}</span>
 }

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -169,11 +169,12 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         {renderInput()}
 
         {!!error && (
-          <Message className={cn(caption ? 'mt-1' : 'absolute top-full translate-y-0.5')} theme={MessageTheme.ERROR}>
+          <Message className="mt-0.5" theme={MessageTheme.ERROR}>
             {error}
           </Message>
         )}
-        {caption && <Caption className={disabled ? 'text-foreground-9' : ''}>{caption}</Caption>}
+
+        {caption && <Caption className={cn({ 'text-foreground-9': disabled })}>{caption}</Caption>}
       </ControlGroup>
     )
   }

--- a/packages/ui/src/components/multi-select.tsx
+++ b/packages/ui/src/components/multi-select.tsx
@@ -1,6 +1,16 @@
 import { ReactNode } from 'react'
 
-import { Button, DropdownMenu, Fieldset, Icon, Label, Message, MessageTheme, ScrollArea, SearchBox } from '@/components'
+import {
+  Button,
+  ControlGroup,
+  DropdownMenu,
+  Icon,
+  Label,
+  Message,
+  MessageTheme,
+  ScrollArea,
+  SearchBox
+} from '@/components'
 import { useDebounceSearch } from '@hooks/use-debounce-search'
 import { cn } from '@utils/cn'
 import { TFunction } from 'i18next'
@@ -11,6 +21,7 @@ export type MultiSelectOptionType<T = unknown> = T & {
 }
 
 export interface MultiSelectProps<T = unknown> {
+  className?: string
   selectedItems: MultiSelectOptionType<Partial<T>>[]
   t: TFunction
   placeholder: string
@@ -24,6 +35,7 @@ export interface MultiSelectProps<T = unknown> {
 }
 
 export const MultiSelect = <T = unknown,>({
+  className,
   selectedItems,
   t,
   placeholder,
@@ -41,9 +53,9 @@ export const MultiSelect = <T = unknown,>({
   })
 
   return (
-    <Fieldset className="gap-y-2">
+    <ControlGroup className={className}>
       {!!label && (
-        <Label className="mb-0.5" color="secondary" htmlFor={''}>
+        <Label className="mb-2.5" color="secondary" htmlFor={''}>
           {label}
         </Label>
       )}
@@ -107,7 +119,7 @@ export const MultiSelect = <T = unknown,>({
         </DropdownMenu.Content>
       </DropdownMenu.Root>
       {!!selectedItems.length && (
-        <div className="flex flex-wrap gap-1.5">
+        <div className="flex flex-wrap gap-1.5 mt-2">
           {selectedItems.map(it => (
             <Button
               key={it.id}
@@ -117,18 +129,21 @@ export const MultiSelect = <T = unknown,>({
               onClick={() => handleChange(it)}
             >
               {it.label}
-              <span className="text-icons-1 transition-colors group-hover:text-foreground-1">
-                <Icon className="rotate-45" name="plus" size={10} />
-              </span>
+              <Icon
+                className="rotate-45 text-icons-1 transition-colors group-hover:text-foreground-1"
+                name="plus"
+                size={10}
+              />
             </Button>
           ))}
         </div>
       )}
+
       {!!error && (
-        <Message className="absolute top-full translate-y-0.5" theme={MessageTheme.ERROR}>
+        <Message className="mt-0.5" theme={MessageTheme.ERROR}>
           {error}
         </Message>
       )}
-    </Fieldset>
+    </ControlGroup>
   )
 }

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -63,12 +63,14 @@ const SelectRoot: FC<SelectRootProps> = ({
       </SelectValue>
     </SelectTrigger>
     {children}
+
     {error && (
-      <Message className={cn(caption ? 'mt-1' : 'absolute top-full translate-y-0.5')} theme={MessageTheme.ERROR}>
+      <Message className="mt-0.5" theme={MessageTheme.ERROR}>
         {error}
       </Message>
     )}
-    {caption && <Caption>{caption}</Caption>}
+
+    {caption && <Caption className={cn({ 'text-foreground-9': disabled })}>{caption}</Caption>}
   </SelectPrimitive.Root>
 )
 SelectRoot.displayName = SelectPrimitive.Root.displayName

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -40,11 +40,11 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           {...props}
         />
         {error && (
-          <Message className={cn(caption ? 'mt-1' : 'absolute top-full translate-y-0.5')} theme={MessageTheme.ERROR}>
+          <Message className="mt-0.5" theme={MessageTheme.ERROR}>
             {error}
           </Message>
         )}
-        {caption && <Caption>{caption}</Caption>}
+        {caption && <Caption className={cn({ 'text-foreground-9': disabled })}>{caption}</Caption>}
       </ControlGroup>
     )
   }

--- a/packages/ui/src/views/profile-settings/profile-settings-general-page.tsx
+++ b/packages/ui/src/views/profile-settings/profile-settings-general-page.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useMemo, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 
 import {
@@ -12,8 +12,7 @@ import {
   FormWrapper,
   Icon,
   Input,
-  Legend,
-  Spacer
+  Legend
 } from '@/components'
 import { SkeletonForm } from '@/components/skeletons'
 import { IProfileSettingsStore, ProfileSettingsErrorType, SandboxLayout, TranslationStore } from '@/views'
@@ -21,24 +20,57 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { getInitials } from '@utils/stringUtils'
 import { z } from 'zod'
 
-const profileSchema = z.object({
-  name: z.string().min(1, { message: 'Please provide your name' }),
-  username: z.string().min(1, { message: 'Please provide a username' }),
-  email: z.string().email({ message: 'Please provide a valid email address' })
-})
-
-const passwordSchema = z
-  .object({
-    newPassword: z.string().min(6, { message: 'New password must be at least 6 characters' }),
-    confirmPassword: z.string().min(6, { message: 'Please confirm your new password' })
+const makeProfileSchema = (t: TranslationStore['t']) =>
+  z.object({
+    name: z
+      .string()
+      .trim()
+      .min(1, { message: t('views:profileSettings.validation.nameMin', 'Please provide your name') })
+      .max(256, {
+        message: t('views:profileSettings.validation.nameMax', 'Name must be no longer than 256 characters')
+      }),
+    username: z
+      .string()
+      .trim()
+      .min(1, {
+        message: t('views:profileSettings.validation.usernameMin', 'Please provide a username')
+      }),
+    email: z
+      .string()
+      .trim()
+      .email({
+        message: t('views:profileSettings.validation.emailInvalid', 'Please provide a valid email address')
+      })
+      .max(250, {
+        message: t('views:profileSettings.validation.emailMax', 'Email must be no longer than 250 characters')
+      })
   })
-  .refine(data => data.newPassword === data.confirmPassword, {
-    message: 'Passwords do not match',
-    path: ['confirmPassword']
-  })
 
-export type ProfileFields = z.infer<typeof profileSchema>
-export type PasswordFields = z.infer<typeof passwordSchema>
+const makePasswordSchema = (t: TranslationStore['t']) =>
+  z
+    .object({
+      newPassword: z
+        .string()
+        .min(6, {
+          message: t('views:profileSettings.validation.passwordMin', 'New password must be at least 6 characters')
+        })
+        .max(128, {
+          message: t(
+            'views:profileSettings.validation.passwordMax',
+            'New password must be no longer than 128 characters'
+          )
+        }),
+      confirmPassword: z.string().min(6, {
+        message: t('views:profileSettings.validation.confirmPasswordMin', 'Please confirm your new password')
+      })
+    })
+    .refine(data => data.newPassword === data.confirmPassword, {
+      message: t('views:profileSettings.validation.passwordsDoNotMatch', 'Passwords do not match'),
+      path: ['confirmPassword']
+    })
+
+export type ProfileFields = z.infer<ReturnType<typeof makeProfileSchema>>
+export type PasswordFields = z.infer<ReturnType<typeof makePasswordSchema>>
 
 interface SettingsAccountGeneralPageProps {
   isLoadingUser: boolean
@@ -55,7 +87,7 @@ interface SettingsAccountGeneralPageProps {
 
 const SUCCESS_MESSAGE_DURATION = 2000
 
-const SettingsAccountGeneralPage: FC<SettingsAccountGeneralPageProps> = ({
+export const SettingsAccountGeneralPage: FC<SettingsAccountGeneralPageProps> = ({
   useProfileSettingsStore,
   isLoadingUser,
   isUpdatingUser,
@@ -72,22 +104,13 @@ const SettingsAccountGeneralPage: FC<SettingsAccountGeneralPageProps> = ({
   const [profileSubmitted, setProfileSubmitted] = useState(false)
   const [passwordSubmitted, setPasswordSubmitted] = useState(false)
 
-  const profileDefaultValues = useMemo(
-    () => ({
-      name: userData?.name || '',
-      username: userData?.username || '',
-      email: userData?.email || ''
-    }),
-    [userData]
-  )
-
   const {
     register: registerProfile,
     handleSubmit: handleProfileSubmit,
     reset: resetProfileForm,
     formState: { errors: profileErrors, isValid: isProfileValid, dirtyFields: profileDirtyFields }
   } = useForm<ProfileFields>({
-    resolver: zodResolver(profileSchema),
+    resolver: zodResolver(makeProfileSchema(t)),
     mode: 'onChange',
     defaultValues: {
       name: userData?.name || '',
@@ -102,7 +125,7 @@ const SettingsAccountGeneralPage: FC<SettingsAccountGeneralPageProps> = ({
     handleSubmit: handlePasswordSubmit,
     formState: { errors: passwordErrors, isValid: isPasswordValid }
   } = useForm<PasswordFields>({
-    resolver: zodResolver(passwordSchema),
+    resolver: zodResolver(makePasswordSchema(t)),
     mode: 'onChange',
     defaultValues: {
       newPassword: '',
@@ -111,21 +134,21 @@ const SettingsAccountGeneralPage: FC<SettingsAccountGeneralPageProps> = ({
   })
 
   useEffect(() => {
-    if (userData) {
-      resetProfileForm(profileDefaultValues)
-    }
-  }, [resetProfileForm, profileDefaultValues, userData])
+    if (!userData) return
+
+    resetProfileForm(userData)
+  }, [resetProfileForm, userData])
 
   useEffect(() => {
-    if (profileUpdateSuccess) {
-      resetProfileForm(profileDefaultValues)
+    if (profileUpdateSuccess && userData) {
+      resetProfileForm(userData)
 
       setProfileSubmitted(true)
       const timer = setTimeout(() => setProfileSubmitted(false), SUCCESS_MESSAGE_DURATION)
 
       return () => clearTimeout(timer)
     }
-  }, [profileUpdateSuccess, resetProfileForm, profileDefaultValues])
+  }, [profileUpdateSuccess, resetProfileForm, userData])
 
   useEffect(() => {
     if (passwordUpdateSuccess) {
@@ -156,23 +179,23 @@ const SettingsAccountGeneralPage: FC<SettingsAccountGeneralPageProps> = ({
 
   return (
     <SandboxLayout.Content className="max-w-[476px] px-0">
-      <h1 className="text-24 font-medium text-foreground-1">
+      <h1 className="text-24 text-foreground-1 mb-10 font-medium">
         {t('views:profileSettings.accountSettings', 'Account settings')}
       </h1>
-      <Spacer size={10} />
-      {isLoadingUser ? (
-        <SkeletonForm />
-      ) : (
+
+      {isLoadingUser && <SkeletonForm />}
+
+      {!isLoadingUser && (
         <>
           <FormWrapper onSubmit={handleProfileSubmit(onProfileSubmit)}>
             <Legend title={t('views:profileSettings.personalInfo', 'Personal information')} />
             {/*
-                 FIXME: Avatar size does not work correctly
-                 issue – https://github.com/harness/canary/issues/817
-              */}
+              FIXME: Avatar size does not work correctly
+              issue – https://github.com/harness/canary/issues/817
+            */}
             <Avatar.Root size="20" className="shadow-md">
               <Avatar.Image src="/images/anon.jpg" />
-              <Avatar.Fallback className="text-24 font-medium text-foreground-3">
+              <Avatar.Fallback className="text-24 text-foreground-3 font-medium">
                 {getInitials(userData?.name || '')}
               </Avatar.Fallback>
             </Avatar.Root>
@@ -234,7 +257,7 @@ const SettingsAccountGeneralPage: FC<SettingsAccountGeneralPageProps> = ({
             </ControlGroup>
           </FormWrapper>
 
-          <FormSeparator className="my-7 border-borders-4" />
+          <FormSeparator className="border-borders-4 my-7" />
 
           <FormWrapper onSubmit={handlePasswordSubmit(onPasswordSubmit)}>
             <Legend
@@ -293,5 +316,3 @@ const SettingsAccountGeneralPage: FC<SettingsAccountGeneralPageProps> = ({
     </SandboxLayout.Content>
   )
 }
-
-export { SettingsAccountGeneralPage }

--- a/packages/ui/src/views/repo/repo-branch-rules/components/repo-branch-rules-fields.tsx
+++ b/packages/ui/src/views/repo/repo-branch-rules/components/repo-branch-rules-fields.tsx
@@ -352,23 +352,14 @@ export const BranchSettingsRuleListField: FC<{
               )}
 
               {!!rule?.hasSelect && isChecked && (
-                <div className="pl-[26px]">
-                  <MultiSelect
-                    selectedItems={rules[index].selectOptions.map(option => ({
-                      id: option,
-                      label: option
-                    }))}
-                    t={t}
-                    placeholder={t('views:repos.selectStatusesPlaceholder', 'Select status checks')}
-                    handleChange={val => handleSelectChangeForRule(rule.id, val.label)}
-                    options={
-                      recentStatusChecks?.map(check => ({
-                        id: check,
-                        label: check
-                      })) ?? []
-                    }
-                  />
-                </div>
+                <MultiSelect
+                  className="pl-[26px]"
+                  selectedItems={rules[index].selectOptions.map(option => ({ id: option, label: option }))}
+                  t={t}
+                  placeholder={t('views:repos.selectStatusesPlaceholder', 'Select status checks')}
+                  handleChange={val => handleSelectChangeForRule(rule.id, val.label)}
+                  options={recentStatusChecks?.map(check => ({ id: check, label: check })) ?? []}
+                />
               )}
 
               {!!rule?.hasInput && isChecked && (


### PR DESCRIPTION
While reviewing the platform's form error handling, we found inconsistencies in approaches and a lack of client-side validation of form values. Some errors are displayed underneath the form inputs, some are shown outside the form, some are displayed in toast messages; validation messages received from the backend are unclear to the user.

Examples of the validation that can be improved:

![image](https://github.com/user-attachments/assets/34792846-3d81-4bc9-9132-76e2f325d6c4)

---

To address this, we validate as many cases as possible on the client side and show messages close to the fields with errors, which improves UX.

This pull-request fixes the validation of **Account settings. General** form:
- `name` and `username` made of spaces are no longer valid
 
![image](https://github.com/user-attachments/assets/f13c7392-2cfc-4407-9019-567bf21e733a)

- `name`, `email`, and `new password` now have max length according to the backend validation
 
![image](https://github.com/user-attachments/assets/d4b3e5ed-1e89-4eba-b9e7-b590f0b50b03)

- validation messages translated into French and Spanish
 
![image](https://github.com/user-attachments/assets/1164c397-c266-4733-8441-09672fe2dd06)

---
This is **part 1** of the validation improvements.